### PR TITLE
add ignored namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ kubectl apply -f example.yaml
 
 ### Environment variables
 
-All environment variables are required.
+All environment variables are required except `IGNORED_NAMESPACES`.
 
 | Name                        | Description                                                               |
 | :-------------------------- | :------------------------------------------------------------------------ |
@@ -34,6 +34,7 @@ All environment variables are required.
 | `REGION`                    | The region of the Kubernetes cluster.                                     |
 | `PROJECT_ID`                | The project ID of the Kubernetes cluster.                                 |
 | `CLUSTER_ID`                | The cluster ID of the Kubernetes cluster.                                 |
+| `IGNORED_NAMESPACES`        | Optional. Comma-separated list of namespaces to ignore.                   |
 
 #### SLACK_NOTIFICATION_CONFIG
 
@@ -57,6 +58,21 @@ Examples
     to `monitoring-coredns` channel.
   - Restarts of other pods in `kube-system` namespace are not notified.
   - Restarts in the other namespaces are notified to `monitoring` channel.
+
+#### IGNORED_NAMESPACES
+
+`IGNORED_NAMESPACES` environment variable defines a comma-separated list of namespaces
+to ignore. Container restarts in these namespaces will not trigger notifications.
+
+Examples:
+
+- `kube-system,monitoring,logging`
+  - Restarts in `kube-system`, `monitoring`, and `logging` namespaces will be ignored.
+- `kube-system, monitoring, logging`
+  - Spaces around commas are allowed and will be trimmed.
+
+This configuration is useful for reducing noise from system namespaces that have frequent
+restarts which aren't relevant to application monitoring.
 
 ### Slack authentication
 

--- a/deployment/example.yaml
+++ b/deployment/example.yaml
@@ -1,3 +1,12 @@
+# 設定値を環境に合わせて変更してください。
+# Please change the following parameters to match your environment.
+#
+# - NAMESPACE: Kubernetesのnamespace
+# - NOTIFICATION_CHANNEL: Slackのチャンネル名または ID
+# - REGION: クラスタがあるリージョン
+# - PROJECT_ID: クラスタがあるプロジェクト ID
+# - CLUSTER_ID: クラスタ ID
+# - IGNORED_NAMESPACES: 無視するNamespace (省略可能)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,6 +47,9 @@ spec:
               value: "<YOUR_PROJECT_ID>"
             - name: CLUSTER_ID
               value: "<YOUR_CLUSTER_ID>"
+            # 無視するNamespaceをカンマ区切りで指定（オプション）
+            # - name: IGNORED_NAMESPACES
+            #   value: "kube-system,monitoring,logging"
           image: ghcr.io/inakam/k8s-restart-notify:latest
           lifecycle:
             preStop:

--- a/deployment/kustomize_example/base/deployment.yaml
+++ b/deployment/kustomize_example/base/deployment.yaml
@@ -37,6 +37,8 @@ spec:
               value: "<YOUR_PROJECT_ID>"
             - name: CLUSTER_ID
               value: "<YOUR_CLUSTER_ID>"
+            - name: IGNORED_NAMESPACES
+              value: "kube-system,default"
           image: ghcr.io/inakam/k8s-restart-notify:latest
           lifecycle:
             preStop:

--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, HashMap, HashSet},
     fmt::Display,
 };
 
@@ -41,12 +41,17 @@ pub async fn watch(
     region: String,
     project_id: String,
     cluster_id: String,
+    ignored_namespaces: HashSet<String>,
 ) -> anyhow::Result<()> {
     // Read pods in all namespaces into the typed interface from k8s-openapi
     let pods: Api<Pod> = Api::all(client.clone());
 
     let notification_config =
         std::env::var("SLACK_NOTIFICATION_CONFIG")?.parse::<NotificationConfig>()?;
+    
+    if !ignored_namespaces.is_empty() {
+        log::info!("Ignoring namespaces: {:?}", ignored_namespaces);
+    }
 
     // Map Pod UID -> container name -> container restart count
     let mut pod_restart_count = HashMap::<String, RestartCounts>::new();
@@ -73,6 +78,7 @@ pub async fn watch(
                     &region,
                     &project_id,
                     &cluster_id,
+                    &ignored_namespaces,
                 )
                 .await?;
             }
@@ -87,6 +93,13 @@ pub async fn watch(
             }
             // Register all living pods in `pod_restart_count`.
             watcher::Event::InitApply(p) => {
+                // 無視するNamespaceリストに含まれている場合は処理をスキップ
+                if let Some(namespace) = p.namespace() {
+                    if ignored_namespaces.contains(&namespace) {
+                        log::debug!("Skipping pod in ignored namespace during init: {}/{}", namespace, p.name_any());
+                        continue;
+                    }
+                }
                 log::info!("Pod detected: {}", PodDisplay(&p));
                 pod_restart_count.insert(p.uid().unwrap(), restarts_in_pod(&p));
             }
@@ -107,7 +120,16 @@ async fn process_applied(
     region: &str,
     project_id: &str,
     cluster_id: &str,
+    ignored_namespaces: &HashSet<String>,
 ) -> anyhow::Result<()> {
+    // 無視するNamespaceリストに含まれている場合は処理をスキップ
+    if let Some(namespace) = p.namespace() {
+        if ignored_namespaces.contains(&namespace) {
+            log::debug!("Skipping pod in ignored namespace: {}/{}", namespace, p.name_any());
+            return Ok(());
+        }
+    }
+
     match pod_restart_count.entry(p.uid().unwrap()) {
         Entry::Occupied(mut entry) => {
             for container in containers(p) {
@@ -415,5 +437,42 @@ mod tests {
         assert_eq!(config.find_channel("foo", "bar", "qux"), Some("default"));
         assert_eq!(config.find_channel("ignore", "bar", "baz"), None);
         assert_eq!(config.find_channel("nomatch", "bar", "baz"), None);
+    }
+    
+    #[test]
+    fn test_ignored_namespaces() {
+        let mut ignored_namespaces = HashSet::new();
+        ignored_namespaces.insert("kube-system".to_string());
+        ignored_namespaces.insert("monitoring".to_string());
+        
+        assert!(ignored_namespaces.contains("kube-system"));
+        assert!(ignored_namespaces.contains("monitoring"));
+        assert!(!ignored_namespaces.contains("default"));
+        assert!(!ignored_namespaces.contains("app"));
+        
+        // IGNORED_NAMESPACES環境変数のパース処理のテスト
+        let env_value = "kube-system,monitoring,logging";
+        let parsed_namespaces = env_value.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<HashSet<String>>();
+        
+        assert_eq!(parsed_namespaces.len(), 3);
+        assert!(parsed_namespaces.contains("kube-system"));
+        assert!(parsed_namespaces.contains("monitoring"));
+        assert!(parsed_namespaces.contains("logging"));
+        assert!(!parsed_namespaces.contains("default"));
+        
+        // 空文字やスペースの処理を確認
+        let env_value = "kube-system, ,monitoring,  ,logging";
+        let parsed_namespaces = env_value.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<HashSet<String>>();
+        
+        assert_eq!(parsed_namespaces.len(), 3);
+        assert!(parsed_namespaces.contains("kube-system"));
+        assert!(parsed_namespaces.contains("monitoring"));
+        assert!(parsed_namespaces.contains("logging"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use kube::Client;
 use tokio::sync::mpsc;
+use std::collections::HashSet;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -15,9 +16,30 @@ async fn main() -> anyhow::Result<()> {
     let region = std::env::var("REGION")?;
     let project_id = std::env::var("PROJECT_ID")?;
     let cluster_id = std::env::var("CLUSTER_ID")?;
+    
+    // 無視するNamespaceのリストを取得
+    let ignored_namespaces = std::env::var("IGNORED_NAMESPACES").ok()
+        .map(|ns| {
+            ns.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<HashSet<String>>()
+        })
+        .unwrap_or_default();
+    
+    if !ignored_namespaces.is_empty() {
+        log::info!("Ignoring namespaces: {:?}", ignored_namespaces);
+    }
 
     let (tx, rx) = mpsc::channel(320);
-    let watch_handle = tokio::spawn(k8s_restart_notify::kubernetes::watch(client, tx, region, project_id, cluster_id));
+    let watch_handle = tokio::spawn(k8s_restart_notify::kubernetes::watch(
+        client, 
+        tx, 
+        region, 
+        project_id, 
+        cluster_id, 
+        ignored_namespaces
+    ));
     let slack_handle = tokio::spawn(k8s_restart_notify::slack::slack_send(slack_token, rx));
 
     watch_handle.await??;

--- a/src/message.rs
+++ b/src/message.rs
@@ -23,7 +23,7 @@ pub struct ContainerRestartInfo {
 impl ContainerRestartInfo {
     pub fn to_message(&self, file_url: &Option<String>) -> serde_json::Value {
         let gke_link = self.build_gke_link();
-        
+
         // Slackに合わせて大まかに揃うようにする
         let container_identity = format!(
             r"Namespace:         {}
@@ -37,11 +37,12 @@ Reason:                {}",
             format_name(&self.node_name),
             format_name(&self.last_state.as_ref().unwrap().reason),
         );
-        
-        let primary_fields = vec![
-            markdown_text(&format!("Restart Count: `{}`", self.restart_count)),
-        ];
-        
+
+        let primary_fields = vec![markdown_text(&format!(
+            "Restart Count: `{}`",
+            self.restart_count
+        ))];
+
         let mut blocks = vec![
             json!({
                 "type": "header",
@@ -73,15 +74,23 @@ Reason:                {}",
                 ]
             }),
         ];
-        
+
         json!(blocks)
     }
-    
+
     /// GKEコンソールへのリンクを生成
     fn build_gke_link(&self) -> String {
         let namespace = self.namespace.as_deref().unwrap_or("default");
         // https://console.cloud.google.com/kubernetes/pod/<region>/<cluster_id>/<namespace>/<pod_name>/details?project=<project_id> を組み立てる
-        format!("{}/{}/{}/{}/{}/details?project={}", GKE_CONSOLE_BASE_URL, self.region, self.cluster_id, namespace, self.pod_name, self.project_id)
+        format!(
+            "{}/{}/{}/{}/{}/details?project={}",
+            GKE_CONSOLE_BASE_URL,
+            self.region,
+            self.cluster_id,
+            namespace,
+            self.pod_name,
+            self.project_id
+        )
     }
 }
 
@@ -172,7 +181,7 @@ mod tests {
         assert_eq!(suffix("こんにちは", 1), "は");
         assert_eq!(suffix("こんにちは", 0), "");
     }
-    
+
     /// テスト用の関数
     fn suffix(text: &str, limit: usize) -> &str {
         if limit == 0 {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context};
+use chrono::Utc;
 use serde_json::json;
 use tokio::sync::mpsc;
-use chrono::Utc;
 
 use crate::message;
 
@@ -50,10 +50,10 @@ async fn upload_log_file(
         Ok(log) if !log.is_empty() => log.to_owned(),
         _empty_or_error => return Ok(None),
     };
-    
+
     // 現在のタイムスタンプを取得
     let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
-    
+
     let title = format!(
         "{}_{}_{}_{}_restart",
         restart_info.namespace.as_ref().unwrap_or(&"".to_owned()),


### PR DESCRIPTION
This pull request introduces a new feature that allows users to specify namespaces to be ignored by the Kubernetes restart notification system. 

In actual production environments, we don't necessarily want to be notified about every Pod restart; there are often specific Namespaces we wish to ignore. Therefore, allowing these Namespaces to be specified via environment variables addresses this requirement.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Added information about the `IGNORED_NAMESPACES` environment variable, including its purpose, usage, and examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R76)

### Configuration Updates:
* [`deployment/example.yaml`](diffhunk://#diff-60beb5b6c941e4642a5afe0a0889c6709a7cab61a98d9b79084daf69b9696f15R1-R9): Added comments and example configuration for the `IGNORED_NAMESPACES` environment variable. [[1]](diffhunk://#diff-60beb5b6c941e4642a5afe0a0889c6709a7cab61a98d9b79084daf69b9696f15R1-R9) [[2]](diffhunk://#diff-60beb5b6c941e4642a5afe0a0889c6709a7cab61a98d9b79084daf69b9696f15R50-R52)
* [`deployment/kustomize_example/base/deployment.yaml`](diffhunk://#diff-b8dde50dac7bdc1fe4b77ce28237f4b5de94723800af33ec57af8fd9ec79f411R40-R41): Added the `IGNORED_NAMESPACES` environment variable to the deployment configuration.

### Application Logic Updates:
* [`src/kubernetes.rs`](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650L2-R2): Updated the `watch` function to accept and handle the `ignored_namespaces` parameter, and added logic to skip processing pods in ignored namespaces. [[1]](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650L2-R2) [[2]](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650R44-R55) [[3]](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650R81) [[4]](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650R96-R102) [[5]](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650R123-R132)
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR3): Added code to read the `IGNORED_NAMESPACES` environment variable and pass it to the `watch` function. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR3) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR20-R42)

### Testing Updates:
* [`src/kubernetes.rs`](diffhunk://#diff-96a285052b2ef727a55ca7d74329e23bb780ea91cf61585fef6fb0b87f011650R441-R477): Added a test to verify the parsing and handling of the `IGNORED_NAMESPACES` environment variable.