### PR TITLE
delete unnecessary code

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -23,6 +23,12 @@ pub struct ContainerRestartInfo {
 impl ContainerRestartInfo {
     pub fn to_message(&self, file_url: &Option<String>) -> serde_json::Value {
         let gke_link = self.build_gke_link();
+        // last_stateがNoneの場合は、reasonを取得する
+        let reason = if let Some(last_state) = &self.last_state {
+            last_state.reason.as_deref().unwrap_or("Unknown")
+        } else {
+            "Unknown"
+        };
 
         // Slackに合わせて大まかに揃うようにする
         let container_identity = format!(


### PR DESCRIPTION
This pull request includes several changes to the `src/message.rs` and `src/slack.rs` files, focusing on refactoring code and removing unnecessary functions. The most important changes include removing the `upload_log_file` function and its related constants and simplifying the `to_message` method in `ContainerRestartInfo`.

Refactoring and simplification:

* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L24-R31): Removed the `file_url` parameter from the `to_message` method in `ContainerRestartInfo` and added logic to handle `last_state` being `None`. [[1]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L24-R31) [[2]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L38-R52)
* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L116-L131): Removed the `to_message` method from `ContainerResources` struct as it was not being used.
* [`src/slack.rs`](diffhunk://#diff-f91531f14dcdc55aecbd46ed2fc6b9a8367962acf96f032f24364fdbf8929e62L1-L10): Removed the `upload_log_file` function and its related constants (`GET_UPLOAD_URL` and `COMPLETE_UPLOAD_URL`) and refactored `post_notification` to no longer call `upload_log_file`. [[1]](diffhunk://#diff-f91531f14dcdc55aecbd46ed2fc6b9a8367962acf96f032f24364fdbf8929e62L1-L10) [[2]](diffhunk://#diff-f91531f14dcdc55aecbd46ed2fc6b9a8367962acf96f032f24364fdbf8929e62L33-R41)
* [`src/slack.rs`](diffhunk://#diff-f91531f14dcdc55aecbd46ed2fc6b9a8367962acf96f032f24364fdbf8929e62L155-L158): Removed the `get_file_url_from_response` function as it is no longer needed.

Formatting improvements:

* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L84-R99): Reformatted the `build_gke_link` method for better readability.